### PR TITLE
Refine graph dataset generation pipeline

### DIFF
--- a/dataset/graph_dataset_gen.py
+++ b/dataset/graph_dataset_gen.py
@@ -1,155 +1,209 @@
-import os
-import torch
+"""Graph dataset generation utilities.
+
+This module builds temporal graph snapshots from raw stock time-series data.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple
+
 import numpy as np
 import pandas as pd
-from datetime import datetime
-from functools import lru_cache
+import torch
+from torch import Tensor
 from torch.utils.data import Dataset
 from tqdm import tqdm
 
-class MyDataset(Dataset):
-    """
-    Dataset of graph snapshots built on sliding windows of stock‐time‐series.
+GraphSample = Dict[str, Tensor]
 
-    Each graph contains node features (X), adjacency matrices (A), and labels (Y).
-    Normalize features by log1p per feature.
-    """
+_EPS = 1e-8
+_NUM_FEATURES = 5  # Open, High, Low, Close, Volume
+
+
+class GraphDataset(Dataset[GraphSample]):
+    """Dataset of sliding-window graph snapshots for stock prediction."""
 
     def __init__(
         self,
-        root: str,
-        desti: str,
+        root: str | Path,
+        destination: str | Path,
         market: str,
-        comlist: list[str],
+        companies: Sequence[str],
         start: str,
         end: str,
         window: int,
         dataset_type: str,
-        sparsification_threshold: float = 1.0
-    ):
+        sparsification_threshold: float = 1.0,
+    ) -> None:
         super().__init__()
-        self.root = root
-        self.desti = desti
+
+        if not companies:
+            raise ValueError("`companies` must contain at least one ticker symbol.")
+        if window <= 1:
+            raise ValueError("`window` must be greater than 1 to compute labels.")
+        if sparsification_threshold <= 0:
+            raise ValueError("`sparsification_threshold` must be positive.")
+
+        self.root = Path(root)
+        self.destination = Path(destination)
         self.market = market
-        self.comlist = comlist
+        self.companies = list(companies)
         self.start = start
         self.end = end
         self.window = window
         self.dataset_type = dataset_type
-        self.sparsification_threshold = sparsification_threshold
+        self.sparsification_threshold = float(sparsification_threshold)
+        self.feature_dim = self.window * _NUM_FEATURES
 
-        # Pre-load all dataframes
-        self._dataframes = {comp: self._load_csv(comp) for comp in self.comlist}
+        self._dataframes: Dict[str, pd.DataFrame] = {
+            company: self._load_company_frame(company) for company in self.companies
+        }
 
-        # Find dates and next common day
         self.dates, self.next_day = self._find_common_dates()
-        if not self.next_day:
-            raise ValueError(f"No common next day after {self.end} for all companies.")
+        self._num_windows = len(self.dates) - self.window + 1
+        if self._num_windows <= 0:
+            raise ValueError(
+                "Not enough common trading days to build even a single window. "
+                "Reduce `window` or adjust the date range."
+            )
 
-        # Prepare output directory
-        self._out_dir = os.path.join(
-            self.desti,
+        self._output_dir = self.destination / (
             f"{self.market}_{self.dataset_type}_{self.start}_{self.end}_{self.window}"
         )
-        os.makedirs(self._out_dir, exist_ok=True)
+        self._output_dir.mkdir(parents=True, exist_ok=True)
 
-        # Generate graphs if missing or incomplete
-        total_windows = len(self.dates) - self.window + 1
-        existing = sorted([f for f in os.listdir(self._out_dir) if f.startswith('graph_')])
-        if len(existing) < total_windows:
+        existing = sorted(self._output_dir.glob("graph_*.pt"))
+        if len(existing) < self._num_windows:
             self._create_graphs()
 
+    # ---------------------------------------------------------------------
+    # Dataset API
     def __len__(self) -> int:
-        return len(self.dates) - self.window + 1
+        return self._num_windows
 
-    def __getitem__(self, idx: int) -> dict:
-        path = os.path.join(self._out_dir, f'graph_{idx}.pt')
-        if not os.path.exists(path):
-            raise FileNotFoundError(f"Missing graph file for index {idx}")
-        return torch.load(path)
+    def __getitem__(self, index: int) -> GraphSample:
+        path = self._graph_path(index)
+        if not path.exists():
+            raise FileNotFoundError(f"Missing graph sample at index {index} ({path})")
+        return torch.load(path, map_location="cpu")
 
-    def _load_csv(self, comp: str) -> pd.DataFrame:
-        """Load company CSV, index by date."""
-        path = os.path.join(self.root, f"{self.market}_{comp}_30Y.csv")
-        df = pd.read_csv(path, parse_dates=[0], index_col=0)
+    # ------------------------------------------------------------------
+    # Data loading helpers
+    def _graph_path(self, index: int) -> Path:
+        return self._output_dir / f"graph_{index}.pt"
+
+    def _load_company_frame(self, company: str) -> pd.DataFrame:
+        csv_path = self.root / f"{self.market}_{company}_30Y.csv"
+        if not csv_path.exists():
+            raise FileNotFoundError(f"Missing CSV file for {company!r}: {csv_path}")
+
+        df = pd.read_csv(csv_path, parse_dates=[0], index_col=0)
+        if df.empty:
+            raise ValueError(f"CSV file {csv_path} is empty.")
+        if df.shape[1] < _NUM_FEATURES:
+            raise ValueError(
+                f"CSV file {csv_path} must contain at least {_NUM_FEATURES} columns "
+                "for the OHLCV features."
+            )
+
         df.index = df.index.normalize()
         return df
 
-    def _find_common_dates(self) -> tuple[list[str], str | None]:
-        """Find common trading dates between start/end and next common date after end."""
-        start_dt = pd.to_datetime(self.start).date()
-        end_dt = pd.to_datetime(self.end).date()
-        max_dates = [df.index.max().date() for df in self._dataframes.values()]
-        bound_dt = min(max_dates)
+    def _find_common_dates(self) -> Tuple[List[pd.Timestamp], pd.Timestamp]:
+        start_ts = pd.Timestamp(self.start)
+        end_ts = pd.Timestamp(self.end)
 
-        valid_sets, after_sets = [], []
-        for df in self._dataframes.values():
-            dates = df.index.date
-            valid = {d.isoformat() for d in dates if start_dt <= d <= end_dt}
-            after = {d.isoformat() for d in dates if end_dt < d <= bound_dt}
-            valid_sets.append(valid)
-            after_sets.append(after)
+        max_dates = [frame.index.max() for frame in self._dataframes.values()]
+        bound_ts = min(max_dates)
+
+        valid_sets: List[set[pd.Timestamp]] = []
+        after_sets: List[set[pd.Timestamp]] = []
+        for frame in self._dataframes.values():
+            index = frame.index
+            valid_mask = (index >= start_ts) & (index <= end_ts)
+            after_mask = (index > end_ts) & (index <= bound_ts)
+            valid_sets.append(set(index[valid_mask]))
+            after_sets.append(set(index[after_mask]))
 
         common = sorted(set.intersection(*valid_sets))
+        if not common:
+            raise ValueError("No common trading days found in the requested range.")
+
         after_common = set.intersection(*after_sets)
-        next_day = min(after_common) if after_common else None
-        return common, next_day
+        if not after_common:
+            raise ValueError("No common trading day available immediately after the end date.")
 
-    def _compute_adjacency(self, features: np.ndarray) -> torch.Tensor:
-        """
-        Build adjacency matrix A where
-        A_ij = log(max((E_i/E_j) * exp(H_i - H_j), threshold))
-        """
-        energy = np.sum(features**2, axis=1) + 1e-8
-        entropy = np.apply_along_axis(
-            lambda row: float(-np.sum(
-                (np.unique(row, return_counts=True)[1] / row.size) *
-                np.log((np.unique(row, return_counts=True)[1] / row.size) + 1e-12)
-            )),
-            1,
-            features
-        )
+        next_day = min(after_common)
+        return [pd.Timestamp(ts) for ts in common], pd.Timestamp(next_day)
 
-        E_ratio = energy[:, None] / energy[None, :]
-        H_diff = np.exp(entropy[:, None] - entropy[None, :])
-        A_np = E_ratio * H_diff
+    # ------------------------------------------------------------------
+    # Feature preparation helpers
+    @staticmethod
+    def _shannon_entropy(matrix: np.ndarray) -> np.ndarray:
+        entropies = np.empty(matrix.shape[0], dtype=np.float64)
+        for idx, row in enumerate(matrix):
+            values, counts = np.unique(row, return_counts=True)
+            probabilities = counts.astype(np.float64) / counts.sum()
+            entropies[idx] = -np.sum(probabilities * np.log(probabilities + _EPS))
+        return entropies
 
-        A_clamped = np.maximum(A_np, self.sparsification_threshold)
-        logA = np.log(A_clamped)
-        return torch.from_numpy(logA).float()
+    def _compute_adjacency(self, node_features: np.ndarray) -> Tensor:
+        node_features = node_features.astype(np.float64, copy=False)
+        energy = np.sum(np.square(node_features), axis=1) + _EPS
+        entropy = self._shannon_entropy(node_features)
+
+        energy_ratio = energy[:, None] / energy[None, :]
+        entropy_ratio = np.exp(entropy[:, None] - entropy[None, :])
+        adjacency = np.maximum(energy_ratio * entropy_ratio, self.sparsification_threshold)
+
+        return torch.from_numpy(np.log(adjacency)).float()
 
     @lru_cache(maxsize=None)
-    def _get_window(self, comp: str, dates_tuple: tuple[str, ...]) -> np.ndarray:
-        """Return normalized windowed feature matrix: log1p + z-score of first 5 cols."""
-        df = self._dataframes[comp].loc[dates_tuple]
-        arr = df.iloc[:, :5].to_numpy()
-        # Log transform
-        norm_arr = np.log1p(arr)
-        return norm_arr
+    def _get_window(self, company: str, dates: Tuple[pd.Timestamp, ...]) -> np.ndarray:
+        frame = self._dataframes[company]
+        window_df = frame.loc[list(dates)]
+        features = window_df.iloc[:, :_NUM_FEATURES].to_numpy(dtype=np.float32, copy=True)
+        return np.log1p(features)
 
-    def _create_graphs(self):
-        """Generate and save graph tensors for each sliding window."""
+    # ------------------------------------------------------------------
+    # Graph generation
+    def _create_graphs(self) -> None:
         all_dates = self.dates + [self.next_day]
 
-        for t in tqdm(range(len(self.dates) - self.window + 1)):
-            out_path = os.path.join(self._out_dir, f'graph_{t}.pt')
-            if os.path.exists(out_path):
+        for index in tqdm(range(self._num_windows), desc="Building graph dataset", unit="win"):
+            path = self._graph_path(index)
+            if path.exists():
                 continue
 
-            window_dates = tuple(all_dates[t:t + self.window + 1])
-            X_list = [self._get_window(c, window_dates[:-1]) for c in self.comlist]
-            X_np = np.stack(X_list, axis=1)
-            X = torch.from_numpy(X_np.transpose(2,1,0)).float()
+            window_dates = tuple(all_dates[index : index + self.window + 1])
+            feature_windows = np.stack(
+                [self._get_window(company, window_dates[:-1]) for company in self.companies],
+                axis=0,
+            )  # (num_companies, window, num_features)
 
-            last_prices = [
-                self._dataframes[c].loc[window_dates[-2:], 'Close'].to_numpy()
-                for c in self.comlist
-            ]
-            last_arr = np.stack(last_prices, axis=0)
-            Y = torch.from_numpy((last_arr[:,1] - last_arr[:,0]) > 0).float()
+            features = torch.from_numpy(feature_windows.reshape(len(self.companies), -1)).float()
 
-            A = torch.stack([
-                self._compute_adjacency(X[f].numpy()) for f in range(X.shape[0])
-            ])
+            feature_matrices = np.transpose(feature_windows, (2, 0, 1))
+            adjacency = torch.stack(
+                [self._compute_adjacency(feature_matrices[feat_idx]) for feat_idx in range(feature_matrices.shape[0])]
+            )
 
-            torch.save({'X': X, 'A': A, 'Y': Y}, out_path)
+            price_changes = np.stack(
+                [
+                    self._dataframes[company]
+                    .loc[list(window_dates[-2:]), "Close"]
+                    .to_numpy(dtype=np.float32, copy=True)
+                    for company in self.companies
+                ],
+                axis=0,
+            )
+            labels = torch.from_numpy((price_changes[:, 1] > price_changes[:, 0]).astype(np.int64))
+
+            torch.save({"X": features, "A": adjacency, "Y": labels}, path)
+
+
+MyDataset = GraphDataset
+
+__all__ = ["GraphDataset", "MyDataset"]


### PR DESCRIPTION
## Summary
- rewrite the graph dataset generator as `GraphDataset` with clear typing, validation, and reusable utilities
- ensure node features flatten into the expected `[num_nodes, window * features]` layout and keep compatibility via a `MyDataset` alias
- tighten adjacency construction, label generation, and filesystem handling while adding helpful error messages

## Testing
- python -m compileall dataset/graph_dataset_gen.py

------
https://chatgpt.com/codex/tasks/task_e_68e2910c5f848329b6d3c4045d2856f7