### PR TITLE
Expose dataset relation count; validate model relation config and seed NumPy RNG

### DIFF
--- a/dataset/graph_dataset_gen.py
+++ b/dataset/graph_dataset_gen.py
@@ -29,6 +29,8 @@ def _ensure_sequence(name: str, values: Iterable[str]) -> List[str]:
 class GraphDataset(Dataset[GraphSample]):
     """Dataset of sliding-window graph snapshots for stock prediction."""
 
+    num_relations = _NUM_FEATURES
+
     def __init__(
         self,
         root: str | Path,
@@ -58,6 +60,7 @@ class GraphDataset(Dataset[GraphSample]):
         self.dataset_type = dataset_type
         self.sparsification_threshold = float(sparsification_threshold)
         self.feature_dim = self.window * _NUM_FEATURES
+        self.num_relations = _NUM_FEATURES
 
         self._dataframes: Dict[str, pd.DataFrame] = {
             company: self._load_company_frame(company) for company in self.companies

--- a/train/train_val_test.py
+++ b/train/train_val_test.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 from typing import Iterator, List, Sequence, Tuple
 
+import numpy as np
 import torch
 import torch.nn.functional as F
 import torch.optim as optim
@@ -24,6 +25,7 @@ from model.multi_gdn import MGDPR  # noqa: E402
 # ─── Reproducibility ────────────────────────────────────────────────────────────
 def set_seed(seed: int = 42) -> None:
     random.seed(seed)
+    np.random.seed(seed)
     torch.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
     torch.backends.cudnn.deterministic = True
@@ -169,6 +171,12 @@ def main(args: argparse.Namespace) -> None:
         args.time_steps,
         "Test",
     )
+
+    if args.num_relation != train_ds.num_relations:
+        raise ValueError(
+            "The number of relations must match the dataset feature relations "
+            f"({train_ds.num_relations})."
+        )
 
     model = MGDPR(
         num_nodes,


### PR DESCRIPTION
### Motivation
- Ensure the number of relation channels produced by the dataset is discoverable and validated against the model configuration to avoid silent shape mismatches.
- Improve reproducibility by seeding the NumPy RNG alongside Python and PyTorch.

### Description
- Add `num_relations` as a class attribute and set `self.num_relations = _NUM_FEATURES` in `GraphDataset` in `dataset/graph_dataset_gen.py` to expose the dataset relation count.
- Seed NumPy in `set_seed` by calling `np.random.seed(seed)` and add `import numpy as np` in `train/train_val_test.py`.
- Add a runtime validation in `main` to check `args.num_relation == train_ds.num_relations` and raise a `ValueError` if they differ.

### Testing
- Compiled the modified modules with `python -m py_compile model/mgd.py model/multi_gdn.py model/paret.py dataset/graph_dataset_gen.py train/train_val_test.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f0d7e6800832990fdf3018cee190c)